### PR TITLE
Add dart-ajax

### DIFF
--- a/example/dart_ajax.dart
+++ b/example/dart_ajax.dart
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+library core_elements.example.dart_ajax;
+
+import 'dart:html';
+
+import 'package:template_binding/template_binding.dart';
+import 'package:polymer/polymer.dart';
+
+main() {
+  initPolymer().run(() {
+    var ajax = querySelector('dart-ajax');
+    ajax.on["core-response"].listen((event) {
+      var detail = event.detail;
+      var response = detail['response'];
+      print(response['feed']['entry']);
+      print(response['feed']['entry'].length);
+      print(response['feed']['entry'][0]['title'][r'$t']);
+
+      templateBind(querySelector('#t1')).model = {
+        'response': response
+      };
+
+      templateBind(querySelector('#t2')).model = {
+        'response': response
+      };
+
+    });
+  });
+}

--- a/example/dart_ajax.html
+++ b/example/dart_ajax.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<!--
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+
+  <title>core-ajax</title>
+
+  <script src="packages/web_components/platform.js"></script>
+  <script src="packages/web_components/dart_support.js"></script>
+  <link rel="import" href="packages/core_elements/dart_ajax/dart_ajax.html">
+
+</head>
+<body>
+
+  <dart-ajax auto url="http://gdata.youtube.com/feeds/api/videos/" 
+      params='{"alt":"json", "q":"chrome"}'
+      handleAs="json"></dart-ajax>
+    
+  <template id="t2" bind repeat="{{ response.feed.entry }}">
+    <div>{{ title.$t }}</div>
+  </template>
+
+  <!-- If this template is not here, the next template does not render :( -->
+  <template id="t1" bind>
+    <div style="border: solid 1px blue;">x: {{ response.feed.entry.0.title.$t }}</div>
+  </template>
+  <script type="application/dart" src="dart_ajax.dart"></script>
+</body>
+</html>

--- a/lib/dart_ajax/dart_ajax.dart
+++ b/lib/dart_ajax/dart_ajax.dart
@@ -1,0 +1,295 @@
+//Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+//This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+//The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+//The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+//Code distributed by Google as part of the polymer project is also
+//subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+
+//<polymer-element name="core-ajax" attributes="url handleAs auto params response method headers body contentType withCredentials">
+
+library core_elements.dart_ajax;
+
+import 'dart:convert' show JSON;
+import 'dart:async';
+import 'dart:html';
+
+import 'package:polymer/polymer.dart';
+import 'package:quiver/core.dart';
+import 'package:quiver/strings.dart';
+
+import 'dart_xhr.dart';
+
+@CustomTag('dart-ajax')
+class DartCoreAjax extends PolymerElement {
+
+  static const _onCoreResponse = const EventStreamProvider('core-response');
+  static const _onCoreComplete = const EventStreamProvider('core-complete');
+  static const _onCoreError = const EventStreamProvider('core-error');
+
+  DartCoreXhr xhr;
+  PolymerJob _goJob;
+// TODO: enable xhrArgs
+//  var xhrArgs;
+
+  DartCoreAjax.created() : super.created() {
+    print("DartCoreAjax.created");
+    this.xhr = document.createElement('dart-xhr');
+  }
+
+  /**
+   * Fired when a response is received.
+   */
+  Stream<CustomEvent> get onCoreResponse => _onCoreResponse.forElement(this);
+
+  /**
+   * Fired when an error is received.
+   */
+  Stream<CustomEvent> get onCoreComplete => _onCoreComplete.forElement(this);
+
+  /**
+   * Fired whenever a response or an error is received.
+   */
+  Stream<CustomEvent> get onCoreError => _onCoreError.forElement(this);
+
+  /**
+   * The URL target of the request.
+   */
+  @published
+  String url = '';
+
+  /**
+   * Specifies what data to store in the `response` property, and
+   * to deliver as `event.response` in `response` events.
+   *
+   * One of:
+   *
+   *    `text`: uses `XHR.responseText`.
+   *
+   *    `xml`: uses `XHR.responseXML`.
+   *
+   *    `json`: uses `XHR.responseText` parsed as JSON.
+   *
+   *    `arraybuffer`: uses `XHR.response`.
+   *
+   *    `blob`: uses `XHR.response`.
+   *
+   *    `document`: uses `XHR.response`.
+   */
+  @published
+  String handleAs = 'text';
+
+  /**
+   * If true, automatically performs an Ajax request when either `url` or `params` changes.
+   */
+  @published
+  bool auto = false;
+
+  /**
+   * Parameters to send to the specified URL, as JSON.
+   */
+  @published
+  String params = '';
+
+  /**
+   * Returns the response object.
+   */
+  @published
+  var response;
+
+  /**
+   * The HTTP method to use such as 'GET', 'POST', 'PUT', or 'DELETE'.
+   * Default is 'GET'.
+   */
+  @published
+  String method = '';
+
+  /**
+   * HTTP request headers to send.
+   *
+   * Example:
+   *
+   *     <core-ajax
+   *         auto
+   *         url="http://somesite.com"
+   *         headers='{"X-Requested-With": "XMLHttpRequest"}'
+   *         handleAs="json"
+   *         on-core-response="{{handleResponse}}"></core-ajax>
+   */
+  @published
+  Map headers = null;
+
+  /**
+   * Optional raw body content to send when method === "POST".
+   *
+   * Example:
+   *
+   *     <core-ajax method="POST" auto url="http://somesite.com"
+   *         body='{"foo":1, "bar":2}'>
+   *     </core-ajax>
+   */
+  String body;
+
+  /**
+   * Content type to use when sending data.
+   *
+   * @default 'application/x-www-form-urlencoded'
+   */
+  String contentType = 'application/x-www-form-urlencoded';
+
+  /**
+   * Set the withCredentials flag on the request.
+   *
+   * @attribute withCredentials
+   * @type boolean
+   * @default false
+   */
+  bool withCredentials = false;
+
+  void receive(response, HttpRequest xhr) {
+    print("receive");
+    if (this.isSuccess(xhr)) {
+      this.processResponse(xhr);
+    } else {
+      this.error(xhr);
+    }
+    this.complete(xhr);
+  }
+
+  bool isSuccess(HttpRequest xhr) {
+    var status = xhr.status;
+    return (status == null) || (status >= 200 && status < 300);
+  }
+
+  void processResponse(xhr) {
+    var response = this.evalResponse(xhr);
+    this.response = response;
+    this.fire('core-response', detail: {'response': response, 'xhr': xhr});
+  }
+
+  void error(xhr) {
+    var response = xhr.status + ': ' + xhr.responseText;
+    this.fire('core-error', detail: {'response': response, 'xhr': xhr});
+  }
+
+  complete(xhr) {
+    this.fire('core-complete', detail: {'response': xhr.status, 'xhr': xhr});
+  }
+
+  evalResponse(xhr) {
+    switch (handleAs) {
+      case 'xml':
+        return xmlHandler(xhr);
+      case 'json':
+        return jsonHandler(xhr);
+      case 'document':
+        return documentHandler(xhr);
+      case 'blob':
+        return blobHandler(xhr);
+      case 'arraybuffer':
+        return arraybufferHandler(xhr);
+      default:
+        return textHandler(xhr);
+    }
+  }
+
+  xmlHandler(HttpRequest xhr) {
+    return xhr.responseXml;
+  }
+
+  textHandler(HttpRequest xhr) {
+    return xhr.responseText;
+  }
+
+  dynamic jsonHandler(HttpRequest xhr) {
+    var r = xhr.responseText;
+    try {
+      return JSON.decode(r);
+    } catch (x) {
+      return r;
+    }
+  }
+
+  documentHandler(HttpRequest xhr) {
+    return xhr.response;
+  }
+
+  blobHandler(HttpRequest xhr) {
+    return xhr.response;
+  }
+
+  arraybufferHandler(HttpRequest xhr) {
+    return xhr.response;
+  }
+
+  urlChanged() {
+    if (!isBlank(this.handleAs)) {
+      var ext = this.url.split('.').last;
+      switch (ext) {
+        case 'json':
+          this.handleAs = 'json';
+          break;
+      }
+    }
+    this.autoGo();
+  }
+
+  paramsChanged() {
+    this.autoGo();
+  }
+
+  autoChanged() {
+    this.autoGo();
+  }
+
+  // TODO(sorvell): multiple side-effects could call autoGo
+  // during one micro-task, use a job to have only one action
+  // occur
+  autoGo() {
+    if (this.auto) {
+      this._goJob = this.scheduleJob(this._goJob, this.go, new Duration());
+    }
+  }
+
+  /**
+   * Performs an Ajax request to the specified URL.
+   *
+   * @method go
+   */
+  go() {
+    // TODO(justinfagnani): support xhrArgs configuration
+/*
+    Map args = firstNonNull(xhrArgs, {});
+     //TODO(sjmiles): we may want XHR to default to POST if body is set
+    var body = firstNonNull(this.body, args.body);
+    var params = firstNonNull(this.params, args.params);
+    if (args.params is String) {
+      args.params = JSON.decode(args.params);
+    }
+    var headers = firstNonNull(this.headers, args.headers, {});
+*/
+    var params = JSON.decode(this.params);
+    var headers = firstNonNull(this.headers, {});
+    if (headers is String) {
+      headers = JSON.decode(headers);
+    }
+    if (this.contentType != null) {
+      headers['content-type'] = this.contentType;
+    }
+    var responseType;
+    if (this.handleAs == 'arraybuffer' || this.handleAs == 'blob' ||
+        this.handleAs == 'document') {
+      responseType = this.handleAs;
+    }
+    return url == null ? null : this.xhr.request(
+        url: url,
+        method: method,
+        headers: headers,
+        body: body,
+        params: params,
+        withCredentials: withCredentials,
+        responseType: responseType,
+        callback: this.receive
+    );
+  }
+
+}

--- a/lib/dart_ajax/dart_ajax.html
+++ b/lib/dart_ajax/dart_ajax.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+
+<link rel="import" href="dart_xhr.html">
+
+<polymer-element name="dart-ajax" attributes="url handleAs auto params response method headers body contentType withCredentials">
+  <script type="application/dart" src="dart_ajax.dart"></script>
+</polymer-element>

--- a/lib/dart_ajax/dart_xhr.dart
+++ b/lib/dart_ajax/dart_xhr.dart
@@ -1,0 +1,120 @@
+//Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+//This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+//The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+//The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+//Code distributed by Google as part of the polymer project is also
+//subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+
+/**
+ * @group Polymer Core Elements
+ *
+ * core-xhr can be used to perform XMLHttpRequests.
+ *
+ *     <core-xhr id="xhr"></core-xhr>
+ *     ...
+ *     this.$.xhr.request({url: url, params: params, callback: callback});
+ *
+ * @element core-xhr
+ */
+
+library core_elements.dart_xhr;
+
+import 'dart:html';
+
+import 'package:polymer/polymer.dart';
+import 'package:quiver/core.dart';
+import 'package:quiver/strings.dart';
+
+typedef void ResponseHandler(response, HttpRequest req);
+
+@CustomTag('dart-xhr')
+class DartCoreXhr extends PolymerElement {
+
+  static const _bodyMethods = const ['POST', 'PUT', 'DELETE'];
+
+  DartCoreXhr.created() : super.created();
+
+  /**
+   * Sends a HTTP request to the server and returns the XHR object.
+   *
+   * String [url] The url to which the request is sent.
+   * String [method] The HTTP method to use, default is GET.
+   * boolean [sync] By default, all requests are sent asynchronously. To send synchronous requests, set to true.
+   * Object [params] Data to be sent to the server.
+   * Object [body] The content for the request body for POST method.
+   * Object [headers] HTTP request headers.
+   * String [responseType] The response type. Default is 'text'.
+   * boolean [withCredentials] Whether or not to send credentials on the request. Default is false.
+   * Object [callback] Called when request is completed.
+   * returns [HttpRequest] object.
+   */
+  HttpRequest request({
+      String url,
+      String method,
+      bool sync,
+      Map params,
+      body,
+      headers,
+      String responseType,
+      bool withCredentials,
+      ResponseHandler callback}) {
+
+    HttpRequest xhr = new HttpRequest();
+    method = isBlank(method) ? 'GET' : method;
+    var async = sync == false;
+
+    String paramsString = _toQueryString(params);
+    if (!isBlank(paramsString) && method == 'GET') {
+      url += (url.indexOf('?') > 0 ? '&' : '?') + paramsString;
+    }
+    var xhrParams = _isBodyMethod(method)
+        ? firstNonNull(body, paramsString)
+        : null;
+
+    xhr.open(method, url, async: async);
+
+    if (!isBlank(responseType)) {
+      xhr.responseType = responseType;
+    }
+    if (withCredentials == true) {
+      xhr.withCredentials = true;
+    }
+    this._makeReadyStateHandler(xhr, callback);
+    this._setRequestHeaders(xhr, headers);
+    xhr.send(xhrParams);
+    if (!async) {
+      // TODO: make this work in Dart
+//          xhr.onreadystatechange(xhr);
+    }
+    return xhr;
+  }
+
+  String _toQueryString(Map params) {
+    var r = [];
+    for (var n in params.keys) {
+      var v = params[n];
+      n = Uri.encodeComponent(n);
+      r.add(v == null ? n : ('$n=${Uri.encodeComponent(v)}'));
+    }
+    return r.join('&');
+  }
+
+  _isBodyMethod(String method) => _bodyMethods.contains(method);
+
+  _makeReadyStateHandler(HttpRequest xhr, ResponseHandler callback) {
+    xhr.onReadyStateChange.listen((_) {
+      if (xhr.readyState == 4) {
+        if (callback != null) callback(xhr.response, xhr);
+      }
+    });
+  }
+
+  _setRequestHeaders(HttpRequest xhr, Map headers) {
+    if (headers != null) {
+      for (var name in headers.keys) {
+        xhr.setRequestHeader(name, headers[name]);
+      }
+    }
+  }
+
+}

--- a/lib/dart_ajax/dart_xhr.html
+++ b/lib/dart_ajax/dart_xhr.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+
+<link rel="import" href="../../../packages/polymer/polymer.html">
+
+<polymer-element name="dart-xhr" hidden>
+  <script type="application/dart" src="dart_xhr.dart"></script>
+</polymer-element>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,7 @@ author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: Core elements for Dart
 dependencies:
   polymer: ">=0.11.0-dev.6 <0.12.0"
+  quiver: ">=0.17.0 <0.19.0"
 dev_dependencies:
   html5lib: ">=0.11.0 <0.12.0"
   path: ">=1.0.0 <2.0.0"
@@ -26,6 +27,7 @@ transformers:
     - example/core_splitter.html
     - example/core_toolbar.html
     - example/core_tooltip.html
+    - example/dart_ajax.html
     - example/dart_list.html
     - example/dart_localstorage.html
     lint: false


### PR DESCRIPTION
Split out core-ajax and core-xhr from the previous PR.

I addressed some of Siggi's comments from the other PR. The others had to do with the state of the code that I ported, style and specific APIs. I tried to make as few changes as possible, so I didn't want to do those now to make tracking easier.

The demo works, but still requires that extra template for some reason.
