### PR TITLE
Make import location configurable

### DIFF
--- a/lib/generate_dart_api.dart
+++ b/lib/generate_dart_api.dart
@@ -26,22 +26,22 @@ main(args) {
     exit(1);
   }
 
-  var configs = {};
+  var config = new GlobalConfig();
   for (var arg in args) {
     if (arg.endsWith('.html')) {
-      configs[arg] = new FileConfig();
+      config.files[arg] = new FileConfig();
     } else if (arg.endsWith('.yaml')) {
       _progress('Parsing configuration ... ');
-      parseConfigFile(arg, configs);
+      parseConfigFile(arg, config);
     }
   }
 
   _progress('Running codegen... ');
-  var len = configs.length;
+  var len = config.files.length;
   int i = 0;
-  configs.forEach((inputPath, config) {
+  config.files.forEach((inputPath, fileConfig) {
     _progress('${++i} of $len: $inputPath');
-    generateDartApi(inputPath, config);
+    generateDartApi(inputPath, fileConfig);
   });
   _progress('Done');
   stdout.write('\n');
@@ -78,8 +78,7 @@ void generateDartApi(String inputPath, FileConfig config) {
     _showMessage('warning: more than one info in $inputPath');
   }
   new File(path.join(outputDir, '$name.dart')).writeAsStringSync(
-      info.elements.map((i) => generateClass(i, config.nameSubstitutions))
-          .join('\n\n'));
+      info.elements.map((i) => generateClass(i, config)).join('\n\n'));
   var extraImports = new StringBuffer();
   for (var jsImport in info.imports) {
     var importPath = jsImport.importPath;

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -11,29 +11,85 @@ library core_elements.src.config;
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 
+/// Holds the entire information parsed from the command line arguments and
+/// configuration files.
+class GlobalConfig {
+  final Map<String, FileConfig> files = {};
+  final List<PackageMapping> packageMappings = [];
+  int _lastUpdated = 0;
+
+  /// Retrieve the package name associated with [elementName].
+  String findPackageNameForElement(String elementName) {
+    if (_lastUpdated != packageMappings.length) {
+      packageMappings.sort();
+    }
+    for (var mapping in packageMappings) {
+      if (elementName.startsWith(mapping.prefix)) return mapping.packageName;
+    }
+    return null;
+  }
+}
+
+class PackageMapping implements Comparable<PackageMapping> {
+  String prefix;
+  String packageName;
+
+  PackageMapping(this.prefix, this.packageName);
+
+  /// Sort in reverse order of the prefix to ensure that longer prefixes are
+  /// matched first.
+  int compareTo(PackageMapping other) => -prefix.compareTo(other.prefix);
+}
+
 /// Configuration information corresponding to a given HTML input file.
 class FileConfig {
+  final GlobalConfig global;
+
+  /// Javascript names that should be substituted when generating Dart code.
   final Map<String, String> nameSubstitutions;
+
+  /// HTML Imports that shold not be mirrored because they don't have a
+  /// corresponding Dart type.
   final List<String> omitImports;
 
-  FileConfig([Map map])
+  /// Dart import to get the base class of a custom element. This is inferred
+  /// normally from the package_mappings, but can be overriden on an individual
+  /// file if necessary.
+  final String extendsImport;
+
+  FileConfig(this.global, [Map map])
     : nameSubstitutions = map != null ? map['name_substitutions'] : null,
-      omitImports = map != null ? map['omit_imports'] : null;
+      omitImports = map != null ? map['omit_imports'] : null,
+      extendsImport = map != null ? map['extends_import'] : null;
 }
 
 /// Parse configurations from a `.yaml` configuration file.
-void parseConfigFile(String filePath, Map<String, FileConfig> result) {
+void parseConfigFile(String filePath, GlobalConfig config) {
   if (!new File(filePath).existsSync()) {
     print("error: file $filePath doesn't exist");
     exit(1);
   }
   var yaml = loadYaml(new File(filePath).readAsStringSync());
-  var toGenerate = yaml['files_to_generate'];
+  _parsePackageMappings(yaml, config);
+  _parseFilesToGenerate(yaml, config);
+}
 
+void _parsePackageMappings(yaml, GlobalConfig config) {
+  var packageMappings = yaml['package_mappings'];
+  if (packageMappings == null) return;
+  for (var entry in packageMappings) {
+    if (entry is! YamlMap) continue;
+    config.packageMappings.add(
+        new PackageMapping(entry.keys.single, entry.values.single));
+  }
+}
+
+void _parseFilesToGenerate(yaml, GlobalConfig config) {
+  var toGenerate = yaml['files_to_generate'];
   if (toGenerate == null) return;
   for (var entry in toGenerate) {
     if (entry is String) {
-      result['lib/src/$entry'] = new FileConfig();
+      config.files['lib/src/$entry'] = new FileConfig(config);
       continue;
     }
 
@@ -43,7 +99,7 @@ void parseConfigFile(String filePath, Map<String, FileConfig> result) {
       continue;
     }
 
-    result['lib/src/${entry.keys.single}'] =
-        new FileConfig(entry.values.single);
+    config.files['lib/src/${entry.keys.single}'] =
+        new FileConfig(config, entry.values.single);
   }
 }


### PR DESCRIPTION
Adds support for configuring how to import the base element. This is implemented with prefix overrides, so everything that starts with a prefix will be mapped to certain package. The order in which prefixes are specified doesn't matter (we'll sort them to make the best match win).

There is also the option to override the import for a specific file. 
R= @justinfagnani 
