### PR TITLE
Add core-scroll-header-panel

### DIFF
--- a/example/core_scroll_header_panel.html
+++ b/example/core_scroll_header_panel.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<!--
+Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>core-scroll-header-panel</title>
+  
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+
+
+  <script src="packages/web_components/platform.js"></script>
+  <script src="packages/web_components/dart_support.js"></script>
+  <link rel="import" href="packages/core_elements/core_scroll_header_panel.html">
+  <link rel="import" href="packages/core_elements/core_toolbar.html">
+  <link rel="import" href="packages/core_elements/core_icon_button.html">
+  
+  <link rel="import" href="packages/core_elements/src/core-scroll-header-panel/demos/lorem-ipsum.html">
+
+  <style shim-shadowdom>
+
+    html, body {
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      color: #333;
+    }
+
+    core-scroll-header-panel {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+    
+    /* background for toolbar when it is at its full size */
+    core-scroll-header-panel::shadow #headerBg {
+      background-image: url(demos/images/bg9.jpg);
+    }
+    
+    /* background for toolbar when it is condensed */
+    core-scroll-header-panel::shadow #condensedHeaderBg {
+      background-color: #f4b400;
+    }
+    
+    core-toolbar {
+      color: #f1f1f1;
+      fill: #f1f1f1;
+    }
+    
+    .title {
+      font-size: 40px;
+    }
+    
+    .content {
+      padding: 10px 30px;
+    }
+
+  </style>
+
+</head>
+<body unresolved>
+
+  <core-scroll-header-panel condenses>
+
+    <core-toolbar class="tall">
+    
+      <core-icon-button icon="arrow-back"></core-icon-button>
+      <div flex></div>
+      <core-icon-button icon="search"></core-icon-button>
+      <core-icon-button icon="more-vert"></core-icon-button>
+      <div class="bottom indent title">Title</div>
+      
+    </core-toolbar>
+    
+    <div class="content">
+      
+      <lorem-ipsum paragraphs="100"></lorem-ipsum>
+      
+    </div>
+    
+  </core-scroll-header-panel>
+  
+  <script type="application/dart">
+    import 'dart:html';
+    import 'dart:math' as Math;
+    import 'package:polymer/polymer.dart';
+  
+    main() {
+      initPolymer().run(() {
+        Polymer.onReady.then((_) {
+          // custom transformation: scale header's title
+          var titleStyle = document.querySelector('.title').style;
+          document.on['core-header-transform'].listen((e) {
+            var d = e.detail;
+            num m = d['height'] - d['condensedHeight'];
+            num y = d['y'];
+            var scale = Math.max(0.75, (m - y) / (m / 0.25)  + 0.75);
+            titleStyle.transform = 'scale($scale) translateZ(0)';
+          });
+        });
+      });
+    }
+  </script>
+  
+</body>
+</html>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ transformers:
     - example/core_pages.html
     - example/core_range.html
     - example/core_scaffold.html
+    - example/core_scroll_header_panel.html
     - example/core_selection.html
     - example/core_selector.html
     - example/core_shared_lib.html


### PR DESCRIPTION
The demo is a little weird, but I can't tell if it's actually wrong. The header is transparent until you start scrolling down, and it goes completely opaque when the head is at the small size. Otherwise, it works well.
