### PR TITLE
add core-style. still lots of issues but is somewhat usable.

### DIFF
--- a/example/core_style.html
+++ b/example/core_style.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+Copyright 2013 The Polymer Authors. All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file.
+-->
+<html>
+<head>
+  <title>core-style</title>
+
+  <script src="packages/web_components/platform.js"></script>
+  <script src="packages/web_components/dart_support.js"></script>
+  
+  <link rel="import" href="core_style/elements.html">
+  <link rel="import" href="core_style/my_theme.html">
+  
+</head>
+<body unresolved fullbleed vertical layout>
+  <core-style ref="main"></core-style>
+
+  <template is="auto-binding">
+    <my-toolbar>
+      <span flex>core-style</span>
+      <input type="color" value="{{g.theme.colorOne}}">
+      <input type="color" value="{{g.theme.colorTwo}}">
+      <input type="color" value="{{g.theme.colorThree}}">
+      <input type="range" min="1" max="8" value="{{g.columns}}">
+      <button>A button</button>
+    </my-toolbar>
+    <section flex horizontal wrap layout>
+      <template repeat="{{item in g.items}}">
+        <my-panel>{{item}}</my-panel>
+      </template>
+    </section>
+  </template>
+
+  <script type="application/dart">
+  import 'dart:js' show JsObject, context;
+  import 'dart:html' show window;
+  import 'package:polymer/polymer.dart' show initMethod, Polymer;
+  export 'package:polymer/init.dart' show main;
+  import 'package:quiver/iterables.dart' show range;
+
+  @initMethod init() {
+    Polymer.onReady.then((_) {
+      context['CoreStyle']['g']['items'] = new JsObject.jsify(range(0, 100));
+
+      window.on['template-bound'].listen((e) {
+        var template = new JsObject.fromBrowserObject(e.target);
+        template['g'] = context['CoreStyle']['g'];
+      });
+    });
+  }
+  </script>
+
+</body>
+</html>
+
+

--- a/example/core_style/elements.html
+++ b/example/core_style/elements.html
@@ -1,0 +1,51 @@
+<link rel="import" href="../packages/core_elements/core_style.html">
+
+<core-style id="my-toolbar">
+  :host {
+    height: 54px;
+    font-size: 1.3rem;
+    background-color: steelblue;
+    color: white;
+  }
+
+  polyfill-next-selector {
+    content: ':host > *';
+  }
+  ::content > * {
+    margin: 8px;
+  }
+</core-style>
+
+<polymer-element name="my-toolbar" horizontal center layout noscript>
+  <template>
+    <core-style ref="my-toolbar"></core-style>
+    <content></content>
+  </template>
+</polymer-element>
+
+<core-style id="my-panel">
+  :host {
+    display: inline-block;
+    height: 200px;
+    width: calc({{ 100 / g.columns }}% - 16px);
+    font-size: 50px;
+    background: gray;
+    margin: 8px;
+  }
+</core-style>
+
+<script type="application/dart">
+import 'dart:js' show context;
+import 'package:polymer/polymer.dart' show initMethod;
+
+@initMethod init() {
+  context['CoreStyle']['g']['columns'] = 3;
+}
+</script>
+
+<polymer-element name="my-panel" vertical center center-justified layout noscript>
+  <template>
+    <core-style ref="my-panel"></core-style>
+    <content></content>
+  </template>
+</polymer-element>

--- a/example/core_style/my_theme.html
+++ b/example/core_style/my_theme.html
@@ -1,0 +1,64 @@
+<link rel="import" href="../packages/core_elements/core_style.html">
+
+<script>
+
+  CoreStyle.g.theme = {
+    colorOne: '#abcdef',
+    colorTwo: '#123456',
+    colorThree: '#224433'
+  }
+</script>
+
+<core-style id="main">
+  body {
+    font-family: sans-serif;
+  }
+
+  section {
+    overflow: auto;
+  }
+
+  button {
+    border: 1px solid {{g.theme.colorOne | cycle(-50)}};
+    border-radius: 4px;
+    background-color: {{g.theme.colorOne}};
+    color: {{g.theme.colorTwo}};
+  }
+
+  button:active {
+    border: 1px solid {{g.theme.colorTwo | cycle(50)}};
+    border-radius: 4px;
+    background-color: {{g.theme.colorTwo}};
+    color: {{g.theme.colorOne}};
+  }
+
+  <template repeat="{{item in g.items}}">
+    my-panel:nth-of-type({{item+1}}) {
+      background-color: {{ g.theme.colorThree | cycle(item * -1) }};
+    }
+  </template>
+</core-style>
+
+<core-style id="my-toolbar">
+  :host {
+    border-bottom: 8px solid {{g.theme.colorOne}};
+    color: {{g.theme.colorOne | cycle(100)}};
+    background-color: {{g.theme.colorTwo}};
+  }
+</core-style>
+
+<core-style id="my-panel">
+  :host {
+    box-sizing: border-box;
+    background-color: {{g.theme.colorOne}};
+    border: 8px solid {{g.theme.colorOne | cycle(50)}};
+    color: {{g.theme.colorOne | cycle(-100)}};
+  }
+
+  :host(:nth-of-type(2n + 1)) {
+    background-color: {{g.theme.colorTwo}};
+    border: 8px solid {{g.theme.colorTwo | cycle(-50)}};
+    color: {{g.theme.colorTwo | cycle(100)}}
+  }
+
+</core-style>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: Polymer core-elements for Dart
 homepage: https://www.dartlang.org/polymer-dart/
 dependencies:
-  polymer: ">=0.11.0-dev.6 <0.12.0"
+  polymer: ">=0.11.0-dev.8 <0.12.0"
   quiver: ">=0.17.0 <0.19.0"
   web_components: ">=0.3.5-dev.3 <0.4.0"
 dev_dependencies:
@@ -42,6 +42,7 @@ transformers:
     - example/core_selector.html
     - example/core_shared_lib.html
     - example/core_splitter.html
+    - example/core_style.html
     - example/core_toolbar.html
     - example/core_tooltip.html
     - example/dart_ajax.html


### PR DESCRIPTION
This still needs a lot of work; using it requires too much interop. Given the global nature of the element, though, I don't think a core-style-dart would really work. Ideally we could have data binding interop, which would probably let us set CoreStyle.g from a Dart object.
