### PR TITLE
Update web_components dependency to 0.4.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://www.dartlang.org/polymer-dart/
 dependencies:
   polymer: ">=0.11.0+1 <0.12.0"
   quiver: ">=0.17.0 <0.19.0"
-  web_components: ">=0.3.5-dev.3 <0.4.0"
+  web_components: ">=0.4.0 <0.5.0"
 dev_dependencies:
   html5lib: ">=0.11.0 <0.12.0"
   path: ">=1.0.0 <2.0.0"


### PR DESCRIPTION
The current constraints are in conflict with Polymer, causing pub to choose the lower version.
