### PR TITLE
DO NOT MERGE: add noSuchMethod proxying to the js element

### DIFF
--- a/example/core_drawer_panel.html
+++ b/example/core_drawer_panel.html
@@ -76,11 +76,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     import 'package:polymer/polymer.dart';
     export 'package:polymer/init.dart' show main;
 
-    _js(x) => new JsObject.fromBrowserObject(x);
-    
     @initMethod init() {
       querySelector('div[main] > button').onClick.listen((_) {
-        _js(querySelector('core-drawer-panel')).callMethod('togglePanel');
+        querySelector('core-drawer-panel').togglePanel();
       });
     }
     </script>

--- a/lib/core_animated_pages.dart
+++ b/lib/core_animated_pages.dart
@@ -4,7 +4,8 @@
 library core_elements.core_animated_pages;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_selector.dart';
@@ -223,6 +224,19 @@ class CoreAnimatedPages extends CoreSelector {
   /// on incoming and outgoing pages.
   get lastSelected => jsElement['lastSelected'];
   set lastSelected(value) { jsElement['lastSelected'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreAnimatedPages() => registerDartType('core-animated-pages', CoreAnimatedPages);

--- a/lib/core_animation.dart
+++ b/lib/core_animation.dart
@@ -4,7 +4,8 @@
 library core_elements.core_animation;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -200,6 +201,19 @@ class CoreAnimation extends HtmlElement with DomProxyMixin {
   /// plays it if autoplay is true.
   apply() =>
       jsElement.callMethod('apply', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreAnimation() => registerDartType('core-animation', CoreAnimation);
@@ -219,6 +233,19 @@ class CoreAnimationKeyframe extends HtmlElement with DomProxyMixin {
   set offset(value) { jsElement['offset'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
 
   get properties => jsElement['properties'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreAnimationKeyframe() => registerDartType('core-animation-keyframe', CoreAnimationKeyframe);
@@ -237,6 +264,19 @@ class CoreAnimationProp extends HtmlElement with DomProxyMixin {
   /// The value for the CSS property.
   get value => jsElement['value'];
   set value(value) { jsElement['value'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreAnimationProp() => registerDartType('core-animation-prop', CoreAnimationProp);

--- a/lib/core_animation_group.dart
+++ b/lib/core_animation_group.dart
@@ -4,7 +4,8 @@
 library core_elements.core_animation_group;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_animation.dart';
@@ -54,6 +55,19 @@ class CoreAnimationGroup extends CoreAnimation {
   get childAnimationElements => jsElement['childAnimationElements'];
 
   get childAnimations => jsElement['childAnimations'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreAnimationGroup() => registerDartType('core-animation-group', CoreAnimationGroup);

--- a/lib/core_collapse.dart
+++ b/lib/core_collapse.dart
@@ -4,7 +4,8 @@
 library core_elements.core_collapse;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -52,6 +53,19 @@ class CoreCollapse extends HtmlElement with DomProxyMixin {
   /// Toggle the opened state.
   void toggle() =>
       jsElement.callMethod('toggle', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreCollapse() => registerDartType('core-collapse', CoreCollapse);

--- a/lib/core_drag_drop.dart
+++ b/lib/core_drag_drop.dart
@@ -4,7 +4,8 @@
 library core_elements.core_drag_drop;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -12,6 +13,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 
 class CoreDragDrop extends HtmlElement with DomProxyMixin {
   CoreDragDrop.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreDragDrop() => registerDartType('core-drag-drop', CoreDragDrop);

--- a/lib/core_drawer_panel.dart
+++ b/lib/core_drawer_panel.dart
@@ -4,7 +4,8 @@
 library core_elements.core_drawer_panel;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -53,6 +54,19 @@ class CoreDrawerPanel extends HtmlElement with DomProxyMixin {
   /// need to show/hide elements based on the layout.
   bool get narrow => jsElement['narrow'];
   set narrow(bool value) { jsElement['narrow'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreDrawerPanel() => registerDartType('core-drawer-panel', CoreDrawerPanel);

--- a/lib/core_field.dart
+++ b/lib/core_field.dart
@@ -4,7 +4,8 @@
 library core_elements.core_field;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -20,6 +21,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 ///     </core-field>
 class CoreField extends HtmlElement with DomProxyMixin {
   CoreField.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreField() => registerDartType('core-field', CoreField);

--- a/lib/core_header_panel.dart
+++ b/lib/core_header_panel.dart
@@ -4,7 +4,8 @@
 library core_elements.core_header_panel;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -112,6 +113,19 @@ class CoreHeaderPanel extends HtmlElement with DomProxyMixin {
   get header => jsElement['header'];
 
   get scroller => jsElement['scroller'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreHeaderPanel() => registerDartType('core-header-panel', CoreHeaderPanel);

--- a/lib/core_icon.dart
+++ b/lib/core_icon.dart
@@ -4,7 +4,8 @@
 library core_elements.core_icon;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -48,6 +49,19 @@ class CoreIcon extends HtmlElement with DomProxyMixin {
   /// the src property should not be.
   String get icon => jsElement['icon'];
   set icon(String value) { jsElement['icon'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreIcon() => registerDartType('core-icon', CoreIcon);

--- a/lib/core_icon_button.dart
+++ b/lib/core_icon_button.dart
@@ -4,7 +4,8 @@
 library core_elements.core_icon_button;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -38,6 +39,19 @@ class CoreIconButton extends HtmlElement with DomProxyMixin {
   /// active state.
   bool get active => jsElement['active'];
   set active(bool value) { jsElement['active'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreIconButton() => registerDartType('core-icon-button', CoreIconButton);

--- a/lib/core_icons.dart
+++ b/lib/core_icons.dart
@@ -4,7 +4,8 @@
 library core_elements.core_icons;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 

--- a/lib/core_iconset.dart
+++ b/lib/core_iconset.dart
@@ -4,7 +4,8 @@
 library core_elements.core_iconset;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_meta.dart';
@@ -109,6 +110,19 @@ class CoreIconset extends CoreMeta {
   ///     with which the icon can be magnified.
   void applyIcon(element,icon,String theme,scale) =>
       jsElement.callMethod('applyIcon', [element,icon,theme,scale]);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreIconset() => registerDartType('core-iconset', CoreIconset);

--- a/lib/core_iconset_svg.dart
+++ b/lib/core_iconset_svg.dart
@@ -4,7 +4,8 @@
 library core_elements.core_iconset_svg;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_meta.dart';
@@ -64,6 +65,19 @@ class CoreIconsetSvg extends CoreMeta {
   ///     defaults to 'updateIcon'
   void updateIcons(String css,String method) =>
       jsElement.callMethod('updateIcons', [css,method]);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreIconsetSvg() => registerDartType('core-iconset-svg', CoreIconsetSvg);

--- a/lib/core_input.dart
+++ b/lib/core_input.dart
@@ -4,7 +4,8 @@
 library core_elements.core_input;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -119,6 +120,19 @@ class CoreInput extends HtmlElement with DomProxyMixin {
   /// Commits the inputValue to value.
   void commit() =>
       jsElement.callMethod('commit', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreInput() => registerDartType('core-input', CoreInput);

--- a/lib/core_item.dart
+++ b/lib/core_item.dart
@@ -4,7 +4,8 @@
 library core_elements.core_item;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -41,6 +42,19 @@ class CoreItem extends HtmlElement with DomProxyMixin {
   /// Specifies the size of the icon in pixel units.
   num get size => jsElement['size'];
   set size(num value) { jsElement['size'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreItem() => registerDartType('core-item', CoreItem);

--- a/lib/core_key_helper.dart
+++ b/lib/core_key_helper.dart
@@ -4,7 +4,8 @@
 library core_elements.core_key_helper;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -12,6 +13,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 
 class CoreKeyHelper extends HtmlElement with DomProxyMixin {
   CoreKeyHelper.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreKeyHelper() => registerDartType('core-key-helper', CoreKeyHelper);

--- a/lib/core_layout_grid.dart
+++ b/lib/core_layout_grid.dart
@@ -4,7 +4,8 @@
 library core_elements.core_layout_grid;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -21,6 +22,19 @@ class CoreLayoutGrid extends HtmlElement with DomProxyMixin {
 
   get auto => jsElement['auto'];
   set auto(value) { jsElement['auto'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreLayoutGrid() => registerDartType('core-layout-grid', CoreLayoutGrid);

--- a/lib/core_layout_trbl.dart
+++ b/lib/core_layout_trbl.dart
@@ -4,7 +4,8 @@
 library core_elements.core_layout_trbl;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -130,6 +131,19 @@ class CoreLayoutTrbl extends HtmlElement with DomProxyMixin {
   /// attribute is applied on this node.
   void layout() =>
       jsElement.callMethod('layout', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreLayoutTrbl() => registerDartType('core-layout-trbl', CoreLayoutTrbl);

--- a/lib/core_media_query.dart
+++ b/lib/core_media_query.dart
@@ -4,7 +4,8 @@
 library core_elements.core_media_query;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -33,6 +34,19 @@ class CoreMediaQuery extends HtmlElement with DomProxyMixin {
   /// The Boolean return value of the media query
   bool get queryMatches => jsElement['queryMatches'];
   set queryMatches(bool value) { jsElement['queryMatches'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreMediaQuery() => registerDartType('core-media-query', CoreMediaQuery);

--- a/lib/core_menu.dart
+++ b/lib/core_menu.dart
@@ -4,7 +4,8 @@
 library core_elements.core_menu;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_selector.dart';
@@ -52,6 +53,19 @@ import 'core_selector.dart';
 ///     }
 class CoreMenu extends CoreSelector {
   CoreMenu.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreMenu() => registerDartType('core-menu', CoreMenu);

--- a/lib/core_menu_button.dart
+++ b/lib/core_menu_button.dart
@@ -4,7 +4,8 @@
 library core_elements.core_menu_button;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -70,6 +71,19 @@ class CoreMenuButton extends HtmlElement with DomProxyMixin {
   /// Toggle the opened state of the dropdown.
   void toggle() =>
       jsElement.callMethod('toggle', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreMenuButton() => registerDartType('core-menu-button', CoreMenuButton);

--- a/lib/core_meta.dart
+++ b/lib/core_meta.dart
@@ -4,7 +4,8 @@
 library core_elements.core_meta;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -72,6 +73,19 @@ class CoreMeta extends HtmlElement with DomProxyMixin {
   /// [id]: The ID of the meta-data to be returned.
   byId(String id) =>
       jsElement.callMethod('byId', [id]);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreMeta() => registerDartType('core-meta', CoreMeta);

--- a/lib/core_overlay.dart
+++ b/lib/core_overlay.dart
@@ -4,7 +4,8 @@
 library core_elements.core_overlay;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -134,6 +135,19 @@ class CoreOverlay extends HtmlElement with DomProxyMixin {
   /// browser window resizes.
   void resizeHandler() =>
       jsElement.callMethod('resizeHandler', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreOverlay() => registerDartType('core-overlay', CoreOverlay);

--- a/lib/core_overlay_layer.dart
+++ b/lib/core_overlay_layer.dart
@@ -4,7 +4,8 @@
 library core_elements.core_overlay_layer;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -12,6 +13,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 
 class CoreOverlayLayer extends HtmlElement with DomProxyMixin {
   CoreOverlayLayer.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreOverlayLayer() => registerDartType('core-overlay-layer', CoreOverlayLayer);

--- a/lib/core_pages.dart
+++ b/lib/core_pages.dart
@@ -4,7 +4,8 @@
 library core_elements.core_pages;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_selector.dart';
@@ -27,6 +28,19 @@ import 'core_selector.dart';
 ///     </script>
 class CorePages extends CoreSelector {
   CorePages.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCorePages() => registerDartType('core-pages', CorePages);

--- a/lib/core_range.dart
+++ b/lib/core_range.dart
@@ -4,7 +4,8 @@
 library core_elements.core_range;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -39,6 +40,19 @@ class CoreRange extends HtmlElement with DomProxyMixin {
   /// Returns the ratio of the value.
   num get ratio => jsElement['ratio'];
   set ratio(num value) { jsElement['ratio'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreRange() => registerDartType('core-range', CoreRange);

--- a/lib/core_scaffold.dart
+++ b/lib/core_scaffold.dart
@@ -4,7 +4,8 @@
 library core_elements.core_scaffold;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -53,6 +54,19 @@ class CoreScaffold extends HtmlElement with DomProxyMixin {
   /// Close the drawer panel
   void closeDrawer() =>
       jsElement.callMethod('closeDrawer', []);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreScaffold() => registerDartType('core-scaffold', CoreScaffold);

--- a/lib/core_scroll_header_panel.dart
+++ b/lib/core_scroll_header_panel.dart
@@ -4,7 +4,8 @@
 library core_elements.core_scroll_header_panel;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -64,6 +65,19 @@ class CoreScrollHeaderPanel extends HtmlElement with DomProxyMixin {
   get header => jsElement['header'];
 
   get scroller => jsElement['scroller'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreScrollHeaderPanel() => registerDartType('core-scroll-header-panel', CoreScrollHeaderPanel);

--- a/lib/core_selection.dart
+++ b/lib/core_selection.dart
@@ -4,7 +4,8 @@
 library core_elements.core_selection;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -83,6 +84,19 @@ class CoreSelection extends HtmlElement with DomProxyMixin {
   /// [item]: The item to toggle.
   void toggle(item) =>
       jsElement.callMethod('toggle', [item]);
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSelection() => registerDartType('core-selection', CoreSelection);

--- a/lib/core_selector.dart
+++ b/lib/core_selector.dart
@@ -4,7 +4,8 @@
 library core_elements.core_selector;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -140,6 +141,19 @@ class CoreSelector extends HtmlElement with DomProxyMixin {
   get items => jsElement['items'];
 
   get selection => jsElement['selection'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSelector() => registerDartType('core-selector', CoreSelector);

--- a/lib/core_shared_lib.dart
+++ b/lib/core_shared_lib.dart
@@ -4,7 +4,8 @@
 library core_elements.core_shared_lib;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -37,6 +38,19 @@ class CoreSharedLib extends HtmlElement with DomProxyMixin {
 
   get callbackName => jsElement['callbackName'];
   set callbackName(value) { jsElement['callbackName'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSharedLib() => registerDartType('core-shared-lib', CoreSharedLib);

--- a/lib/core_signals.dart
+++ b/lib/core_signals.dart
@@ -4,7 +4,8 @@
 library core_elements.core_signals;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -30,6 +31,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 /// of where they are in DOM.
 class CoreSignals extends HtmlElement with DomProxyMixin {
   CoreSignals.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSignals() => registerDartType('core-signals', CoreSignals);

--- a/lib/core_slide.dart
+++ b/lib/core_slide.dart
@@ -4,7 +4,8 @@
 library core_elements.core_slide;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -27,6 +28,19 @@ class CoreSlide extends HtmlElement with DomProxyMixin {
 
   get targetId => jsElement['targetId'];
   set targetId(value) { jsElement['targetId'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSlide() => registerDartType('core-slide', CoreSlide);

--- a/lib/core_splitter.dart
+++ b/lib/core_splitter.dart
@@ -4,7 +4,8 @@
 library core_elements.core_splitter;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -60,6 +61,19 @@ class CoreSplitter extends HtmlElement with DomProxyMixin {
   /// Disables the selection of text while the splitter is being moved
   get disableSelection => jsElement['disableSelection'];
   set disableSelection(value) { jsElement['disableSelection'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSplitter() => registerDartType('core-splitter', CoreSplitter);

--- a/lib/core_style.dart
+++ b/lib/core_style.dart
@@ -4,7 +4,8 @@
 library core_elements.core_style;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -109,6 +110,19 @@ class CoreStyle extends HtmlElement with DomProxyMixin {
   /// inside another.
   get list => jsElement['list'];
   set list(value) { jsElement['list'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreStyle() => registerDartType('core-style', CoreStyle);

--- a/lib/core_submenu.dart
+++ b/lib/core_submenu.dart
@@ -4,7 +4,8 @@
 library core_elements.core_submenu;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -54,6 +55,19 @@ class CoreSubmenu extends HtmlElement with DomProxyMixin {
   set valueattr(value) { jsElement['valueattr'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
 
   get items => jsElement['items'];
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreSubmenu() => registerDartType('core-submenu', CoreSubmenu);

--- a/lib/core_toolbar.dart
+++ b/lib/core_toolbar.dart
@@ -4,7 +4,8 @@
 library core_elements.core_toolbar;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -48,6 +49,19 @@ import 'package:core_elements/src/common.dart' show DomProxyMixin;
 ///     </core-toolbar>
 class CoreToolbar extends HtmlElement with DomProxyMixin {
   CoreToolbar.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreToolbar() => registerDartType('core-toolbar', CoreToolbar);

--- a/lib/core_tooltip.dart
+++ b/lib/core_tooltip.dart
@@ -4,7 +4,8 @@
 library core_elements.core_tooltip;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'package:core_elements/src/common.dart' show DomProxyMixin;
@@ -61,6 +62,19 @@ class CoreTooltip extends HtmlElement with DomProxyMixin {
   /// If true, the tooltip displays by default.
   bool get show => jsElement['show'];
   set show(bool value) { jsElement['show'] = value; }
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreTooltip() => registerDartType('core-tooltip', CoreTooltip);

--- a/lib/core_transition.dart
+++ b/lib/core_transition.dart
@@ -4,7 +4,8 @@
 library core_elements.core_transition;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_meta.dart';
@@ -12,6 +13,19 @@ import 'core_meta.dart';
 
 class CoreTransition extends CoreMeta {
   CoreTransition.created() : super.created();
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreTransition() => registerDartType('core-transition', CoreTransition);

--- a/lib/core_transition_css.dart
+++ b/lib/core_transition_css.dart
@@ -4,7 +4,8 @@
 library core_elements.core_transition_css;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 import 'core_transition.dart';
@@ -15,6 +16,19 @@ class CoreTransitionCss extends CoreTransition {
 
   get transitionType => jsElement['transitionType'];
   set transitionType(value) { jsElement['transitionType'] = (value is Map || value is Iterable) ? new JsObject.jsify(value) : value;}
+
+  noSuchMethod(Invocation invocation) {
+    String methodName = MirrorSystem.getName(invocation.memberName);
+    if (invocation.isMethod && jsElement[methodName] is JsFunction) {
+      print('Warning, passing missing method call ${methodName} to '
+            'JS element. This may impact performance, and should be wrapped '
+            'explicitely in dart.');
+      jsElement.callMethod(
+          methodName, invocation.positionalArguments);
+    } else {
+      super.noSuchMethod(invocation);
+    }
+  }
 }
 @initMethod
 upgradeCoreTransitionCss() => registerDartType('core-transition-css', CoreTransitionCss);

--- a/lib/web_animations.dart
+++ b/lib/web_animations.dart
@@ -4,7 +4,8 @@
 library core_elements.web_animations;
 
 import 'dart:html';
-import 'dart:js' show JsArray, JsObject;
+import 'dart:js' show JsArray, JsObject, JsFunction;
+import 'dart:mirrors';
 import 'package:web_components/interop.dart' show registerDartType;
 import 'package:polymer/polymer.dart' show initMethod;
 


### PR DESCRIPTION
I just wanted to get some feedback from you guys on doing something like this. I understand that it will have a potentially significant impact on the performance, but it would enable generic support for methods which is a pretty big win and would alleviate a lot of the pain that people are seeing since functions seem to be rarely annotated in on the JS side and thus don't get properly wrapped by our code generator.

I am mostly curious about whether we have any actual benchmarks on how this affects the code. Is it worth my time to see how this affects the dart2js output?
