### PR TITLE
remove workaround for #52 (missing `item` getter)

### DIFF
--- a/test/core_selector_basic.dart
+++ b/test/core_selector_basic.dart
@@ -7,13 +7,13 @@
 
 library core_selector.test.basic;
 
-import "dart:async" as async;
-import "dart:html" as dom;
-import "dart:js" as js;
-import "package:polymer/polymer.dart";
-import "package:unittest/unittest.dart";
-import "package:unittest/html_config.dart" show useHtmlConfiguration;
-import "package:core_elements/core_selector.dart" show CoreSelector;
+import 'dart:async' as async;
+import 'dart:html' as dom;
+import 'dart:js' as js;
+import 'package:polymer/polymer.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/html_config.dart' show useHtmlConfiguration;
+import 'package:core_elements/core_selector.dart' show CoreSelector;
 
 void oneMutation(dom.Element node, options, Function cb) {
   var o = new dom.MutationObserver((List<dom.MutationRecord>
@@ -21,7 +21,7 @@ void oneMutation(dom.Element node, options, Function cb) {
     cb();
     observer.disconnect();
   });
-  o.observe(node, attributes: options["attributes"]);
+  o.observe(node, attributes: options['attributes']);
 }
 
 void main() {
@@ -30,44 +30,43 @@ void main() {
   initPolymer().run(() {
     Polymer.onReady.then((e) {
 
-      group("core-selector", () {
+      group('core-selector', () {
 
-        test("basic", () {
+        test('basic', () {
           // selector1
-          var s = (dom.document.querySelector("#selector1") as CoreSelector);
-          expect(s.selectedClass, equals("core-selected"));
+          var s = (dom.document.querySelector('#selector1') as CoreSelector);
+          expect(s.selectedClass, equals('core-selected'));
           expect(s.multi, isFalse);
-          expect(s.valueattr, equals("name"));
-          // TODO(zoechi) expect(s.items.length, equals(5)); // see #52 items getter not available
-          expect(s.jsElement['items']['length'], equals(5));
+          expect(s.valueattr, equals('name'));
+          expect(s.items.length, equals(5));
 
           // selector2
-          s = (dom.document.querySelector("#selector2") as CoreSelector);
-          expect(s.selected, equals("item3"));
-          expect(s.selectedClass, equals("my-selected"));
+          s = (dom.document.querySelector('#selector2') as CoreSelector);
+          expect(s.selected, equals('item3'));
+          expect(s.selectedClass, equals('my-selected'));
           // setup listener for core-select event
           var selectEventCounter = 0;
-          s.on["core-select"].listen((dom.CustomEvent e) {
-            // TODO(zoechi)if (e.detail["isSelected"]) { // event detail is null https://code.google.com/p/dart/issues/detail?id=19315
+          s.on['core-select'].listen((dom.CustomEvent e) {
+            // TODO(zoechi)if (e.detail['isSelected']) { // event detail is null https://code.google.com/p/dart/issues/detail?id=19315
             var detail = new js.JsObject.fromBrowserObject(e)['detail'];
-            if (detail["isSelected"]) {
+            if (detail['isSelected']) {
               selectEventCounter++;
               // selectedItem and detail.item should be the same
-              expect(detail["item"], equals(s.selectedItem));
+              expect(detail['item'], equals(s.selectedItem));
             }
           });
           // set selected
-          s.selected = "item5";
+          s.selected = 'item5';
           return new async.Future.delayed(new Duration(milliseconds: 50), () {
             // check core-select event
             expect(selectEventCounter, equals(1));
             // check selected class
-            expect(s.children[4].classes.contains("my-selected"), isTrue);
+            expect(s.children[4].classes.contains('my-selected'), isTrue);
             // check selectedItem
             expect(s.selectedItem, equals(s.children[4]));
             // selecting the same value shouldn't fire core-select
             selectEventCounter = 0;
-            s.selected = "item5";
+            s.selected = 'item5';
             // TODO(ffu): would be better to wait for something to happen
             // instead of not to happen
             new async.Future.delayed(new Duration(milliseconds: 50), () {

--- a/test/core_selector_basic.html
+++ b/test/core_selector_basic.html
@@ -11,10 +11,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <head>
     <title>core-selector-basic</title>
 
-    <script src="packages/web_components/platform.js"></script>
-    <script src="packages/web_components/dart_support.js"></script>
+    <script src='packages/web_components/platform.js'></script>
+    <script src='packages/web_components/dart_support.js'></script>
 
-    <link rel="import" href="packages/core_elements/core_selector.html">
+    <link rel='import' href='packages/core_elements/core_selector.html'>
 
     <style>
       .core-selected {
@@ -26,10 +26,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <script type="application/dart" src="core_selector_basic.dart"></script>
+    <script type='application/dart' src='core_selector_basic.dart'></script>
   </head>
   <body>
-    <core-selector id="selector1">
+    <core-selector id='selector1'>
       <div>Item 1</div>
       <div>Item 2</div>
       <div>Item 3</div>
@@ -39,12 +39,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <br><br>
 
-    <core-selector id="selector2" selected="item3" selectedClass="my-selected" valueattr="id">
-      <div id="item1">Item 1</div>
-      <div id="item2">Item 2</div>
-      <div id="item3">Item 3</div>
-      <div id="item4">Item 4</div>
-      <div id="item5">Item 5</div>
+    <core-selector id='selector2' selected='item3' selectedClass='my-selected' valueattr='id'>
+      <div id='item1'>Item 1</div>
+      <div id='item2'>Item 2</div>
+      <div id='item3'>Item 3</div>
+      <div id='item4'>Item 4</div>
+      <div id='item5'>Item 5</div>
     </core-selector>
   </body>
 </html>

--- a/test/core_selector_multi.dart
+++ b/test/core_selector_multi.dart
@@ -7,13 +7,13 @@
 
 library core_selector.test.multi;
 
-import "dart:async" as async;
-import "dart:html" as dom;
-import "dart:js" as js;
-import "package:polymer/polymer.dart";
-import "package:unittest/unittest.dart";
-import "package:unittest/html_config.dart" show useHtmlConfiguration;
-import "package:core_elements/core_selector.dart" show CoreSelector;
+import 'dart:async' as async;
+import 'dart:html' as dom;
+import 'dart:js' as js;
+import 'package:polymer/polymer.dart';
+import 'package:unittest/unittest.dart';
+import 'package:unittest/html_config.dart' show useHtmlConfiguration;
+import 'package:core_elements/core_selector.dart' show CoreSelector;
 
 void oneMutation(dom.Element node, options, Function cb) {
   var o = new dom.MutationObserver((List<dom.MutationRecord>
@@ -21,7 +21,7 @@ void oneMutation(dom.Element node, options, Function cb) {
     cb();
     observer.disconnect();
   });
-  o.observe(node, attributes: options["attributes"]);
+  o.observe(node, attributes: options['attributes']);
 }
 
 void main() {
@@ -30,23 +30,22 @@ void main() {
   initPolymer().run(() {
     Polymer.onReady.then((e) {
 
-      group("core-selector", () {
+      group('core-selector', () {
 
-        test("core-selector-multi", () {
+        test('core-selector-multi', () {
           // selector1
-          var s = (dom.document.querySelector("#selector") as CoreSelector);
+          var s = (dom.document.querySelector('#selector') as CoreSelector);
           expect(s.selected, isNull);
-          expect(s.selectedClass, equals("core-selected"));
+          expect(s.selectedClass, equals('core-selected'));
           expect(s.multi, isTrue);
-          expect(s.valueattr, equals("name"));
-          // TODO(zoechi) expect(s.items.length, equals(5)); // getter items not available, see #52
-          expect(s.jsElement['items']['length'], equals(5));
+          expect(s.valueattr, equals('name'));
+          expect(s.items.length, equals(5));
           // setup listener for polymer-select event
           var selectEventCounter = 0;
-          s.on["core-select"].listen((dom.CustomEvent e) {
+          s.on['core-select'].listen((dom.CustomEvent e) {
             // TODO(zoechi)event detail is null https://code.google.com/p/dart/issues/detail?id=19315
             var detail = new js.JsObject.fromBrowserObject(e)['detail'];
-            if (detail["isSelected"]) {
+            if (detail['isSelected']) {
               selectEventCounter++;
             } else {
               selectEventCounter--;
@@ -60,17 +59,17 @@ void main() {
             // check polymer-select event
             expect(selectEventCounter, equals(2));
             // check selected class
-            expect(s.children[0].classes.contains("core-selected"), isTrue);
-            expect(s.children[2].classes.contains("core-selected"), isTrue);
+            expect(s.children[0].classes.contains('core-selected'), isTrue);
+            expect(s.children[2].classes.contains('core-selected'), isTrue);
             // check selectedItem
             expect(s.selectedItem.length, equals(2));
             expect(s.selectedItem[0], equals(s.children[0]));
             expect(s.selectedItem[1], equals(s.children[2]));
             // tap on already selected element should unselect it
-            s.children[0].dispatchEvent(new dom.CustomEvent("tap", canBubble: true));
+            s.children[0].dispatchEvent(new dom.CustomEvent('tap', canBubble: true));
             // check selected
             expect(s.selected.length, equals(1));
-            expect(s.children[0].classes.contains("core-selected"), isFalse);
+            expect(s.children[0].classes.contains('core-selected'), isFalse);
           });
         });
 

--- a/test/core_selector_multi.html
+++ b/test/core_selector_multi.html
@@ -11,10 +11,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <head>
     <title>core-selector-basic</title>
 
-    <script src="packages/web_components/platform.js"></script>
-    <script src="packages/web_components/dart_support.js"></script>
+    <script src='packages/web_components/platform.js'></script>
+    <script src='packages/web_components/dart_support.js'></script>
 
-    <link rel="import" href="packages/core_elements/core_selector.html">
+    <link rel='import' href='packages/core_elements/core_selector.html'>
 
     <style>
       .core-selected {
@@ -22,10 +22,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }
     </style>
 
-    <script type="application/dart" src="core_selector_multi.dart"></script>
+    <script type='application/dart' src='core_selector_multi.dart'></script>
   </head>
   <body>
-    <core-selector id="selector" multi>
+    <core-selector id='selector' multi>
       <div>Item 1</div>
       <div>Item 2</div>
       <div>Item 3</div>


### PR DESCRIPTION
real changes:
- core_selector_basic.dart L41-L42
- core_selector_multi.dart L42-43

everything else just to fix quotes
