### PR TITLE
Fix for core-ajax-dart when status == 0

### DIFF
--- a/lib/core_ajax_dart.dart
+++ b/lib/core_ajax_dart.dart
@@ -160,7 +160,7 @@ class CoreAjax extends PolymerElement {
 
   bool isSuccess(HttpRequest xhr) {
     var status = xhr.status;
-    return (status == null) || (status >= 200 && status < 300);
+    return (status == null || status == 0) || (status >= 200 && status < 300);
   }
 
   void processResponse(xhr) {


### PR DESCRIPTION
When  serving the code from file:/// URLs (rather than a server) the status is 0. This would match what core-ajax does here: https://github.com/Polymer/core-ajax/blob/master/core-ajax.html#L205

@jakemac53 @justinfagnani 
