### PR TITLE
Fix core ajax content-type header.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Pub version 0.2.1+2
+  * Fix for [107](https://github.com/dart-lang/core-elements/issues/107).
+    The `core-ajax-dart` element no longer throws exception in checked mode, and
+    the `content-type` header will have the proper default.
+
 ## Pub version 0.2.1+1
 
   * Update `core-input` element to

--- a/lib/core_ajax_dart.dart
+++ b/lib/core_ajax_dart.dart
@@ -282,7 +282,8 @@ class CoreAjax extends PolymerElement {
     var hasContentType = headers.keys.any((header) {
       return header.toLowerCase() == 'content-type';
     });
-    if (!hasContentType && this.contentType) {
+    if (!hasContentType && this.contentType != null
+        && !this.contentType.isEmpty) {
       headers['Content-Type'] = this.contentType;
     }
     var responseType;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: core_elements
-version: 0.2.1+1
+version: 0.2.1+2
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: Polymer core-elements for Dart
 homepage: https://www.dartlang.org/polymer-dart/

--- a/test/core_ajax_dart_test.dart
+++ b/test/core_ajax_dart_test.dart
@@ -8,6 +8,7 @@
 library core_ajax.test;
 
 import "dart:html" as dom;
+import "package:core_elements/core_ajax_dart.dart";
 import "package:polymer/polymer.dart";
 import "package:unittest/unittest.dart";
 import "package:unittest/html_config.dart" show useHtmlConfiguration;
@@ -20,14 +21,25 @@ void main() {
 
       group("core-ajax", () {
 
-        test("basic", () {
+        test("auto basic", () {
           var done = expectAsync(() {});
 
-          var s = dom.document.querySelector("core-ajax-dart");
+          var s = dom.document.querySelector("#auto");
           s.addEventListener("core-response", (event) {
             expect(event.detail['response']['feed']['entry'].length, greaterThan(0));
             done();
           });
+        });
+
+        test("no auto basic", () {
+          var done = expectAsync(() {});
+
+          var s = dom.document.querySelector("#manual");
+          s.addEventListener("core-response", (event) {
+            expect(event.detail['response']['feed']['entry'].length, greaterThan(0));
+            done();
+          });
+          (s as CoreAjax).go();
         });
 
       });

--- a/test/core_ajax_dart_test.html
+++ b/test/core_ajax_dart_test.html
@@ -18,10 +18,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </head>
   <body>
     <core-ajax-dart
+      id="auto"
       url="core_ajax_dart.json"
       params='{"alt":"json", "q":"chrome"}'
       handleAs="json"
       auto></core-ajax-dart>
+    <core-ajax-dart
+      id="manual"
+      url="core_ajax_dart.json"
+      params='{"alt":"json", "q":"chrome"}'
+      handleAs="json"></core-ajax-dart>
     <script type="application/dart" src="core_ajax_dart_test.dart"></script>
   </body>
 </html>


### PR DESCRIPTION
This was a port fail from the js side of things, gotta watch out for those booleans! Fixes https://github.com/dart-lang/core-elements/issues/107.

Also added a test for the manual version of the element.
