### PR TITLE
add test for update selection by modifying bound field

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ transformers:
         - example/core_animated_pages/shadow
     entry_points:
     - example/core_a11y_keys.html
-    - example/core_ajax_dart.htmlp
+    - example/core_ajax_dart.html
     - example/core_animated_pages/grid.html
     - example/core_animated_pages/list.html
     - example/core_animated_pages/music.html
@@ -80,6 +80,7 @@ transformers:
     - test/core_animated_pages_test.html
     - test/core_collapse_test.html
     - test/core_input_test.html
+    - test/core_list_dart_test.html
     - test/core_localstorage_dart_test.html
     - test/core_media_query_test.html
     - test/core_media_query_dialog_test.html

--- a/test/core_list_dart_test.dart
+++ b/test/core_list_dart_test.dart
@@ -35,18 +35,16 @@ void main() {
   initPolymer().run(() {
     return Polymer.onReady.then((_) {
 
-      group('core-list-dart', () {
+      skip_test('update selection from model', () {
+        var template =
+            dom.document.querySelector('#bindSelectionTemplate')
+                as AutoBindingElement;
+        var model = template.model = new MyModel();
+        var done1 = expectAsync(() {});
 
-        test('update selection from model', () {
-          final template =
-              dom.document.querySelector('#bindSelectionTemplate')
-                  as AutoBindingElement;
-          final model = template.model = new MyModel();
-          final done1 = expectAsync(() {});
-
-          return new Future(() {
-            final list = dom.document.querySelector('#bindSelection')
-                as CoreList;
+        return new Future(() {
+          var list = dom.document.querySelector('#bindSelection')
+              as CoreList;
 
 // TODO(zoechi) check if this event should be fired when selection was changed
 // probably not because the doc says `Fired when an item element is tapped`
@@ -57,15 +55,13 @@ void main() {
 //              done1();
 //            });
 
-            model.selection = model.data[0];
-            return new Future(() {
-              final foundSelected =
-                  dom.document.querySelector('#bindSelection .selected');
-              expect(foundSelected.innerHtml, contains(model.data[0].value));
-            });
+          model.selection = model.data[0];
+          return new Future(() {
+            var foundSelected =
+                dom.document.querySelector('#bindSelection .selected');
+            expect(foundSelected.innerHtml, contains(model.data[0].value));
           });
         });
-
       });
 
     });


### PR DESCRIPTION
I tried to bind the `selection` attribute to a field in my model 

``` html
<core-list-dart id="menu"
                      data="{{model.filtered}}"
                      selection="{{model.activeItem}}"
                      class="children" flex height="16">
```

and expected when I assign an item to `model.activeItem` that `core-list-dart` shows this item as selected but it doesn't.
The PR contains a test which verifies this behavior
