### PR TITLE
offset -> animationOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
+## version 0.6.0-dev
+  * The `offset` property of the `core-animation` element is now called
+    `animationOffset` so that it won't conflict with the `offset` property in
+    its base class, `HtmlElement`.
+
 ## version 0.5.0+2
-  * core-list-dart no longer crashes if the window is resized before the list
+  * `core-list-dart` no longer crashes if the window is resized before the list
     data is initialized.
 
 ## version 0.5.0+1

--- a/core_elements_config.yaml
+++ b/core_elements_config.yaml
@@ -11,7 +11,9 @@ files_to_generate:
   - core-animated-pages/transitions/hero-transition.html:
       omit_imports:
         - core-transition-pages.html
-  - core-animation/core-animation.html
+  - core-animation/core-animation.html:
+      name_substitutions:
+        offset: animationOffset
   - core-animation/core-animation-group.html
   - core-animation/web-animations.html
   - core-collapse/core-collapse.html

--- a/lib/core_animation.dart
+++ b/lib/core_animation.dart
@@ -214,8 +214,8 @@ class CoreAnimationKeyframe extends HtmlElement with DomProxyMixin, PolymerProxy
   factory CoreAnimationKeyframe() => new Element.tag('core-animation-keyframe');
 
   /// An offset from 0 to 1.
-  num get offset => jsElement[r'offset'];
-  set offset(num value) { jsElement[r'offset'] = value; }
+  num get animationOffset => jsElement[r'offset'];
+  set animationOffset(num value) { jsElement[r'offset'] = value; }
 
   get properties => jsElement[r'properties'];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: core_elements
-version: 0.5.0+2
+version: 0.6.0-dev
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: Polymer core-elements for Dart
 homepage: https://www.dartlang.org/polymer/


### PR DESCRIPTION
Technically a breaking change... although I hate to bump the version again. What do you think @sigmundch?

Fyi the reason for this is HtmlElement in dart has an `offset` property which returns a rectangle. This doesn't exist in the js world.
