### PR TITLE
Fix for "Cannot read property 'position' of null"

### DIFF
--- a/lib/src/core-dropdown/core-dropdown.html
+++ b/lib/src/core-dropdown/core-dropdown.html
@@ -183,13 +183,16 @@ not scroll with its container.
     resetTargetDimensions: function() {
       var dims = this.dimensions;
       var style = this.target.style;
-      if (dims.position.h_by === this.localName) {
-        style[dims.position.h] = null;
-        dims.position.h_by = null;
-      }
-      if (dims.position.v_by === this.localName) {
-        style[dims.position.v] = null;
-        dims.position.v_by = null;
+      // Dims may be not define 
+      if(dims) {
+          if (dims.position.h_by === this.localName) {
+              style[dims.position.h] = null;
+              dims.position.h_by = null;
+          }
+          if (dims.position.v_by === this.localName) {
+              style[dims.position.v] = null;
+              dims.position.v_by = null;
+          }
       }
       this.super();
     },


### PR DESCRIPTION
I was impacted by the bug reported at https://github.com/Polymer/core-dropdown/issues/11. Someone graciously created a quick fix at https://github.com/Polymer/core-dropdown/pull/14, but it has yet to be merged (don't know why). After some quick testing it works great. I don't know if you'd rather that be merged first and ignore this request, but either way it needs to be merged in somewhere as this was giving my app troubles.